### PR TITLE
comment-report-format option allows to summarize report comment by each changed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Default is "reg_actions".
 
 The option to disable push to a branch. When set to false, the `branch` option is ignored, and images will not be displayed in the comments.
 
+#### `comment-report-format` (Optional)
+
+- Type: String
+- Default: `"raw"`
+
+The option how to render changed file in comment. This action will change PR and workflow summary report format. Available options are `raw` and `summarized`. `raw` will render report comment with expanded results. `summarized` will render report comment using `<details>` tag to summarize by changed files.
 
 ## Limitation
 

--- a/dist/action.yml
+++ b/dist/action.yml
@@ -40,7 +40,10 @@ inputs:
     required: false
   report-file-path:
     description: "Path of the generated report html file. This file can be deployed in other Actions steps, but is not included in the artifact. If omitted, no html report is generated."
-    required: false    
+    required: false
+  comment-report-format:
+    description: "The option how to render changed file in comment. `raw` by default."
+    required: false
 runs:
   using: "node20"
   main: "lib/index.js"

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export interface Config {
   disableBranch: boolean;
   customReportPage: string | null;
   reportFilePath: string | null;
+  commentReportFormat: 'raw' | 'summarized';
 }
 
 const validateGitHubToken = (githubToken: string | undefined) => {
@@ -94,6 +95,12 @@ const validateReportFilePath = (path: string | undefined) => {
   }
 };
 
+function validateCommentReportFormat(format: string): asserts format is 'raw' | 'summarized' {
+  if (format !== 'raw' && format !== 'summarized') {
+    throw new Error(`'comment-report-format' input must be 'raw' or 'summarized' but got '${format}'`);
+  }
+}
+
 export const getConfig = (): Config => {
   const githubToken = core.getInput('github-token');
   const imageDirectoryPath = core.getInput('image-directory-path');
@@ -112,6 +119,8 @@ export const getConfig = (): Config => {
   validateCustomReportPage(customReportPage);
   const reportFilePath = core.getInput('report-file-path');
   validateReportFilePath(reportFilePath);
+  const commentReportFormat = core.getInput('comment-report-format') || 'raw';
+  validateCommentReportFormat(commentReportFormat);
 
   return {
     githubToken,
@@ -126,5 +135,6 @@ export const getConfig = (): Config => {
     disableBranch: getBoolInput(core.getInput('disable-branch')),
     customReportPage,
     reportFilePath,
+    commentReportFormat,
   };
 };

--- a/src/service.ts
+++ b/src/service.ts
@@ -200,6 +200,7 @@ export const run = async ({
     regBranch: config.branch,
     customReportPage: config.customReportPage,
     disableBranch: config.disableBranch,
+    commentReportFormat: config.commentReportFormat,
   });
 
   await client.postComment(event.number, comment);


### PR DESCRIPTION
## Motivation

When we have multiple file changes, sometimes we want to view only a specific changed file. Current comment format is difficult to find a specific changed file.

## Solution

Add a `comment-report-format: "summarized"` config. It make add more `<details>` tag into each changed file.

## Debug

just kick sample repository using forked github action.

<details><summary>with `comment-report-format: "summarized"` config</summary>

reports can be expanded by each file.

```yaml
    - uses: krrrr38/reg-actions@comment-report-format-summarized-dist
      with:
        ...
        comment-report-format: "summarized"
```

<img width="689" alt="image" src="https://github.com/reg-viz/reg-actions/assets/915731/a9359f5c-a436-409e-b89c-79f245a57800">
</details>

<details><summary>without `comment-report-format` config</summary>

no changed behaviors.

```yaml
    - uses: krrrr38/reg-actions@comment-report-format-summarized-dist
      with:
        ...
        # comment-report-format: "summarized"
```

<img width="629" alt="image" src="https://github.com/reg-viz/reg-actions/assets/915731/1aec46ff-6e03-45a8-a876-e407f9bed559">

</details>