### PR TITLE
add cleanup workspace directory when init

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -89,6 +89,15 @@ const compareAndUpload = async (client: UploadClient, config: Config): Promise<C
 
 const init = async (config: Config) => {
   log.info(`start initialization with config.`, config);
+
+  // Cleanup workspace
+  await fs.promises.rm(workspace(), {
+    recursive: true,
+    force: true
+  });
+
+  log.info(`Succeeded to cleanup workspace.`);
+  
   // Create workspace
   await makeDir(workspace());
 


### PR DESCRIPTION
I want to use reg-actions twice in the same job as follows

```
- uses: reg-viz/reg-actions@v2
  with:
    github-token: '${{ secrets.GITHUB_TOKEN }}'
    image-directory-path: 'hoge'
    artifact-name: 'hoge'

- uses: reg-viz/reg-actions@v2
  with:
    github-token: '${{ secrets.GITHUB_TOKEN }}'
    image-directory-path: 'fuga'
    artifact-name: 'fuga'
```

In the second reg-actions, the workspace is not cleaned up, so the previous workspace is taken over.
Therefore, an implementation has been added to delete the workspace at init.