### PR TITLE
feat: outdated comment action option to minimize previous reg-action comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ The option to disable push to a branch. When set to false, the `branch` option i
 
 The option how to render changed file in comment. This action will change PR and workflow summary report format. Available options are `raw` and `summarized`. `raw` will render report comment with expanded results. `summarized` will render report comment using `<details>` tag to summarize by changed files.
 
+#### `outdated-comment-action` (Optional)
+
+- Type: String
+- Default: `"none"`
+
+The option to handle outdated comments in the PR. Available options are `none` and `minimize`. `none` do nothing. `minimize` will minimize outdated action comments.
+
 ## Limitation
 
 - If the `artifact` is deleted, the report will also be deleted, see [`Artifact and log retention policy`](https://docs.github.com/ja/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy) for the retention period of the `artifact`.

--- a/dist/action.yml
+++ b/dist/action.yml
@@ -44,6 +44,9 @@ inputs:
   comment-report-format:
     description: "The option how to render changed file in comment. `raw` by default."
     required: false
+  outdated-comment-action:
+    description: "The option to handle outdated comments. `none` by default."
+    required: false
 runs:
   using: "node20"
   main: "lib/index.js"

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -283,3 +283,9 @@ ${report}
 
   return body;
 };
+
+export const isRegActionComment = ({ artifactName, body }: { artifactName: string; body: string }): boolean => {
+  return (
+    body.includes(`## ArtifactName: \`${artifactName}\``) || body.includes(`## ArtifactName: [\`${artifactName}\`]`)
+  );
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface Config {
   customReportPage: string | null;
   reportFilePath: string | null;
   commentReportFormat: 'raw' | 'summarized';
+  outdatedCommentAction: 'none' | 'minimize';
 }
 
 const validateGitHubToken = (githubToken: string | undefined) => {
@@ -101,6 +102,12 @@ function validateCommentReportFormat(format: string): asserts format is 'raw' | 
   }
 }
 
+function validateOutdatedCommentAction(action: string): asserts action is 'none' | 'minimize' {
+  if (action !== 'none' && action !== 'minimize') {
+    throw new Error(`'outdated-comment-action' input must be 'none' or 'minimized' but got '${action}'`);
+  }
+}
+
 export const getConfig = (): Config => {
   const githubToken = core.getInput('github-token');
   const imageDirectoryPath = core.getInput('image-directory-path');
@@ -121,6 +128,8 @@ export const getConfig = (): Config => {
   validateReportFilePath(reportFilePath);
   const commentReportFormat = core.getInput('comment-report-format') || 'raw';
   validateCommentReportFormat(commentReportFormat);
+  const outdatedCommentAction = core.getInput('outdated-comment-action') || 'none';
+  validateOutdatedCommentAction(outdatedCommentAction);
 
   return {
     githubToken,
@@ -136,5 +145,6 @@ export const getConfig = (): Config => {
     customReportPage,
     reportFilePath,
     commentReportFormat,
+    outdatedCommentAction,
   };
 };


### PR DESCRIPTION
closes https://github.com/reg-viz/reg-actions/issues/137

# Verification

run this impl on private repository.

- package into forked repository https://github.com/krrrr38/reg-actions/tree/myv2
- use this action and run ci multi times

<img width="973" alt="image" src="https://github.com/reg-viz/reg-actions/assets/915731/f748ad2a-8900-4d96-bb96-b04176eb0206">

<img width="993" alt="image" src="https://github.com/reg-viz/reg-actions/assets/915731/1441599a-feee-4207-8bf9-f0888761a80f">
