### PR TITLE
docs: Link to English instead of Japanese GitHub documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This option allows you to specify the duration for which images are stored in th
 
 ## Limitation
 
-- If the `artifact` is deleted, the report will also be deleted, see [`Artifact and log retention policy`](https://docs.github.com/ja/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy) for the retention period of the `artifact`.
+- If the `artifact` is deleted, the report will also be deleted, see [`Artifact and log retention policy`](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy) for the retention period of the `artifact`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Since the language of the README is English, it would be consistent to also link to the English GitHub Documentation.