### PR TITLE
Copy files after comparison is complete

### DIFF
--- a/src/compare.ts
+++ b/src/compare.ts
@@ -33,16 +33,6 @@ export const compare = async (config: Config): Promise<CompareOutput> =>
       enableAntialias: config.enableAntialias,
     });
 
-    if (config.reportFilePath) {
-      log.info(`reportFilePath ${config.reportFilePath} detected`);
-      try {
-        await cpy(workspace() + '/**/*', config.reportFilePath);
-        log.info(`Succeeded to copy reg data to ${config.reportFilePath}.`);
-      } catch (e) {
-        log.error(`Failed to copy reg data to ${config.reportFilePath} reason: ${e}`);
-      }
-    }
-
     emitter.on('complete', result => {
       log.debug('compare result', result);
       log.info('Comparison Complete');
@@ -52,4 +42,15 @@ export const compare = async (config: Config): Promise<CompareOutput> =>
       log.info(chalk.green('   Passed items: ' + result.passedItems.length));
       resolve(result);
     });
+  }).then(async (result) => {
+    if (config.reportFilePath) {
+      log.info(`reportFilePath ${config.reportFilePath} detected`);
+      try {
+        await cpy(workspace() + '/**/*', config.reportFilePath);
+        log.info(`Succeeded to copy reg data to ${config.reportFilePath}.`);
+      } catch (e) {
+        log.error(`Failed to copy reg data to ${config.reportFilePath} reason: ${e}`);
+      }
+    }
+    return result
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     "types": ["@types/node"],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -58,6 +58,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Issue.

Copy operation is executed before the comparison process is completed and report files are not copied to `reportFilePath`.

## Workaround

Use the Promise chain to copy a group of files at the timing when the comparison process is completely finished.

## Other

Due to the issue listed in the following Issue, CI/CD type checking on forked repositories always fails, so `tsconfig.json` is also fixed.

https://github.com/isaacs/node-lru-cache/issues/354

## Example

Only `01_actual` and report are copied because of newly added images only.

| [Using Actions before modification](https://github.com/totto2727-org/lapriere-website/actions/runs/11010670160/job/30573188839) | [Using the modified Actions](https://github.com/totto2727-org/lapriere-website/actions/runs/11011741324/job/30576541232) |
| - | - |
| <img width="493" alt="スクリーンショット 2024-09-25 11 10 57" src="https://github.com/user-attachments/assets/ac3a03c4-2bd5-405f-884b-5b93abb8189b"> | <img width="501" alt="スクリーンショット 2024-09-25 11 12 34" src="https://github.com/user-attachments/assets/0ca898e2-461d-4727-95b4-74857ea3ec55"> |